### PR TITLE
Fix failing spec for AudioSpace#frequency_at_y.

### DIFF
--- a/app/audiospace.spec.coffee
+++ b/app/audiospace.spec.coffee
@@ -133,7 +133,7 @@ describe 'AudioSpace', ->
       spyOn(audio_space.scale, 'get_active_frequency').and.returnValue(50)
       for n in [0..4]
         expect(audio_space.frequency_at_y(n * 100)).toEqual(50)
-        expect(audio_space.scale.get_active_frequency).toHaveBeenCalledWith(n / 4)
+        expect(audio_space.scale.get_active_frequency).toHaveBeenCalledWith(1 - (n / 4))
         audio_space.scale.get_active_frequency.calls.reset()
       
   describe '#crossfade_at_x', ->


### PR DESCRIPTION
This should have been done as part of @pachunka's previous PR, https://github.com/sarahquigley/phoneophone/pull/21, but was accidentally forgotten!
